### PR TITLE
Fixed nav from scroll-locking

### DIFF
--- a/js/vendor/jquery.lightnav.js
+++ b/js/vendor/jquery.lightnav.js
@@ -99,7 +99,7 @@
 	            }
 	        });
 
-			if (!$(this).children('ul').length) {
+			if (!$(this).children('ul').length && !$(this).parent('ul').hasClass('main-nav')) {
 				$('.lightnav-button').click(); // close nav since there are no children
 			}
 	    });


### PR DESCRIPTION
The jquery that was a clicking .lightnav-button (line 103) was causing
it to also click the desktop version of the ul. Added a line to be more
specific, and cancelling out the div class 'main-nav'.